### PR TITLE
update prompt to avoid repeated info

### DIFF
--- a/backend/app/services/resume_prompts.rb
+++ b/backend/app/services/resume_prompts.rb
@@ -237,6 +237,7 @@ module ResumePrompts
 
       IMPORTANT: Do not include any additional text or comments in the JSON output. Do not include any ```json or ``` in the output.
       IMPORTANT: Provide ONLY the JSON output, no other text or comments.
+      IMPORTANT: Any given position or activity must only be listed in a single section.
 
       {
     PROMPT
@@ -279,7 +280,7 @@ module ResumePrompts
       IMPORTANT: Do not include any additional text or comments in the LaTeX output. Do not include any ```latex or ``` in the LaTeX output.
       IMPORTANT: Do not add unnecessary or additional formatting beyond what is already in the template.
       IMPORTANT: Provide ONLY the LaTeX output, no other text or comments.
-      IMPORTANT: Do not repeat information throughout the resume. A position or activity must only be listed once.
+      IMPORTANT: Any given position or activity must only be listed in a single section. Avoid repetition.
       \\documentclass
     PROMPT
   end

--- a/backend/app/services/resume_prompts.rb
+++ b/backend/app/services/resume_prompts.rb
@@ -279,6 +279,7 @@ module ResumePrompts
       IMPORTANT: Do not include any additional text or comments in the LaTeX output. Do not include any ```latex or ``` in the LaTeX output.
       IMPORTANT: Do not add unnecessary or additional formatting beyond what is already in the template.
       IMPORTANT: Provide ONLY the LaTeX output, no other text or comments.
+      IMPORTANT: Do not repeat information throughout the resume. A position or activity must only be listed once.
       \\documentclass
     PROMPT
   end


### PR DESCRIPTION
<img width="744" alt="Screenshot 2025-02-22 at 9 50 18 PM" src="https://github.com/user-attachments/assets/a84121f0-568b-4d2d-be2e-33b86b9dea10" />
<img width="749" alt="Screenshot 2025-02-22 at 9 50 36 PM" src="https://github.com/user-attachments/assets/84501b47-4a4c-40dc-b794-d8a1e1ce7f30" />

when reformatting my resume, a lot of information was duplicated. 3 positions were copied into a new sectionscalled leadership / extracurricular. I saw that the prompt already states no new sections, but maybe an extra line explicitly disallowing repeated info would help